### PR TITLE
Support for setting CA cert, client cert and client keys,

### DIFF
--- a/src/ESP32MQTTClient.cpp
+++ b/src/ESP32MQTTClient.cpp
@@ -42,6 +42,21 @@ void ESP32MQTTClient::setTaskPrio(int prio)
     _mqtt_config.task_prio = prio;
 }
 
+void ESP32MQTTClient::setClientCert(const char * clientCert)
+{
+	 _mqtt_config.client_cert_pem = clientCert;
+}
+
+void ESP32MQTTClient::setCaCert(const char * caCert)
+{
+	 _mqtt_config.cert_pem = caCert;
+}
+
+void ESP32MQTTClient::setKey(const char * clientKey)
+{
+	_mqtt_config.client_key_pem = clientKey;
+		
+}
 // =============== Public functions for interaction with thus lib =================
 
 void ESP32MQTTClient::setConnectionState(bool state)

--- a/src/ESP32MQTTClient.h
+++ b/src/ESP32MQTTClient.h
@@ -15,6 +15,7 @@ class ESP32MQTTClient
 private:
     esp_mqtt_client_config_t _mqtt_config; // C so different naming
     esp_mqtt_client_handle_t _mqtt_client;
+	
 
     // MQTT related
     bool _mqttConnected;
@@ -63,6 +64,9 @@ public:
     //void loop();
 
     // MQTT related
+	void setClientCert(const char * clientCert);
+	void setCaCert(const char * caCert);
+	void setKey(const char * clientKey);
     void setOnMessageCallback();
     void setConnectionState(bool state);
     void setAutoReconnect(bool choice);


### PR DESCRIPTION
Expose support for setting CA cert, client cert and client keys, which is required to connect to the AWS IoT MQTT server.