### PR TITLE
initialize lastwill strings to nullptr

### DIFF
--- a/src/ESP32MQTTClient.cpp
+++ b/src/ESP32MQTTClient.cpp
@@ -5,6 +5,8 @@ ESP32MQTTClient::ESP32MQTTClient(/* args */)
     _mqttConnected = false;
     _mqttMaxInPacketSize = 1024;
     _mqttMaxOutPacketSize = _mqttMaxInPacketSize;
+    _mqttLastWillTopic = nullptr;
+    _mqttLastWillMessage = nullptr;
 }
 
 ESP32MQTTClient::~ESP32MQTTClient()


### PR DESCRIPTION
without initializing these, we assign garbage to the internal `mqtt_client` struct's `lastwill` struct unless `EnableLastWillMessage()` is called. this usually manifests as an IllegalInstruction or ProhibitedLoad exception.

probably we ought be initializing more than just this, but this is absolutely necessary.