### PR TITLE
Fix buffer overflow in setURL() method

### DIFF
--- a/src/ESP32MQTTClient.h
+++ b/src/ESP32MQTTClient.h
@@ -67,7 +67,6 @@ private:
 public:
     // Constants
     static constexpr uint16_t DEFAULT_PACKET_SIZE = 1024;
-    static constexpr uint16_t URI_BUFFER_SIZE = 200;
 
     ESP32MQTTClient(/* args */);
     ~ESP32MQTTClient();
@@ -113,17 +112,29 @@ public:
             free(_mqttUriBuffer);
             _mqttUriBuffer = nullptr;
         }
-        
-        // Allocate new buffer
-        _mqttUriBuffer = (char *)malloc(URI_BUFFER_SIZE);
-        if (port == 8883)
-        {
-            sprintf(_mqttUriBuffer, "mqtts://%s:%u", url, port);
+
+        if (url == nullptr) {
+            if (_enableSerialLogs) {
+                ESP_LOGE("ESP32MQTTClient", "URL is null");
+            }
+            return;
         }
-        else
-        {
-            sprintf(_mqttUriBuffer, "mqtt://%s:%u", url, port);
+
+        // Dynamically calculate required space: mqtt(s):// + url + :65535 + \0
+        size_t urlLen = strlen(url);
+        size_t needed = urlLen + 16;  // Enough for scheme + port + terminator
+
+        _mqttUriBuffer = (char *)malloc(needed);
+        if (_mqttUriBuffer == nullptr) {
+            if (_enableSerialLogs) {
+                ESP_LOGE("ESP32MQTTClient", "Failed to allocate memory for MQTT URI");
+            }
+            return;
         }
+
+        const char* scheme = (port == 8883) ? "mqtts" : "mqtt";
+        snprintf(_mqttUriBuffer, needed, "%s://%s:%u", scheme, url, port);
+
         if (_enableSerialLogs)
         {
             ESP_LOGI("ESP32MQTTClient", "MQTT uri %s", _mqttUriBuffer);

--- a/src/ESP32MQTTClient.h
+++ b/src/ESP32MQTTClient.h
@@ -111,6 +111,7 @@ public:
         if (_mqttUriBuffer != nullptr) {
             free(_mqttUriBuffer);
             _mqttUriBuffer = nullptr;
+            _mqttUri = nullptr;
         }
 
         if (url == nullptr) {


### PR DESCRIPTION
## Summary

Fixes #28 - Buffer overflow vulnerability in `ESP32MQTTClient::setURL()` when users provide long URLs.

## Problem

The original implementation used a fixed-size buffer (`URI_BUFFER_SIZE = 200` bytes). When calling `sprintf(_mqttUriBuffer, "mqtts://%s:%u", url, port)`, if the URL string exceeded ~184 characters, it would cause a buffer overflow.

## Solution

Replace fixed-size allocation with dynamic allocation based on actual URL length:

- Calculate required space: `strlen(url) + 16` bytes (enough for `mqtt(s)://` + port + terminator)
- Use `snprintf` instead of `sprintf` for additional safety
- Add `nullptr` check for the URL parameter
- Remove the hardcoded `URI_BUFFER_SIZE` constant

## Testing

- [ ] Long URL (> 200 chars) should no longer cause overflow
- [ ] Normal URLs continue to work as expected
- [ ] Memory allocation failure is handled gracefully

## API Compatibility

No breaking changes - the function signature remains identical.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)