### PR TITLE
Fix uninitialized _mqttLastWillQos and zero-initialize _mqtt_config

### DIFF
--- a/src/ESP32MQTTClient.cpp
+++ b/src/ESP32MQTTClient.cpp
@@ -6,11 +6,14 @@ static const char *TAG = "ESP32MQTTClient";
 
 ESP32MQTTClient::ESP32MQTTClient(/* args */)
 {
+    memset(&_mqtt_config, 0, sizeof(_mqtt_config));
     _mqttConnected = false;
     _mqttMaxInPacketSize = DEFAULT_PACKET_SIZE;
     _mqttMaxOutPacketSize = _mqttMaxInPacketSize;
     _mqttLastWillTopic = nullptr;
     _mqttLastWillMessage = nullptr;
+    _mqttLastWillQos = 0;
+    _mqttLastWillRetain = false;
     _mqttUriBuffer = nullptr;
     _globalMessageReceivedCallback = nullptr;
 }


### PR DESCRIPTION
## Summary

Fixes #31.

- Initialize `_mqttLastWillQos` to `0` to prevent undefined behavior when `enableLastWillMessage()` is called and the uninitialized value is later passed to `setConfigLwt()` / `esp_mqtt_client_init()`.
- Initialize `_mqttLastWillRetain` to `false` for defensive programming.
- `memset` `_mqtt_config` to zero to ensure all unset `esp_mqtt_client_config_t` fields have known default values, avoiding garbage values across both ESP-IDF v4.x and v5.x APIs.

## Root Cause

`enableLastWillMessage()` set `_mqttLastWillTopic`, `_mqttLastWillMessage`, and `_mqttLastWillRetain`, but never set `_mqttLastWillQos`. The constructor also did not initialize it. When `loopStart()` later called `setConfigLwt()` with this garbage value, it was fed directly into `esp_mqtt_client_init()`, leading to undefined behavior.

Additionally, `_mqtt_config` (a `esp_mqtt_client_config_t` POD struct member) was never zero-initialized, leaving many unconfigured fields with indeterminate values.

## Test plan

- [ ] CI builds pass (Arduino + ESP-IDF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)